### PR TITLE
Add support for Rails 4.1

### DIFF
--- a/lib/comatose_page.rb
+++ b/lib/comatose_page.rb
@@ -92,7 +92,7 @@ class ComatosePage < ActiveRecord::Base
   def self.find_by_path( path )
      path = path.split('.')[0] unless path.empty? # Will ignore file extension...
      path = path[1..-1] if path.starts_with? "/"
-     find( :first, :conditions=>[ 'full_path = ?', path ] )
+     where(:full_path => path).first
   end
 
 # Overrides...

--- a/lib/liquid/strainer.rb
+++ b/lib/liquid/strainer.rb
@@ -5,7 +5,7 @@ module Liquid
   #
   # One of the strainer's responsibilities is to keep malicious method calls out 
   class Strainer
-    @@required_methods = ["__send__", "__id__", "respond_to?", "extend", "methods"]
+    @@required_methods = ["__send__", "__id__", "object_id", "respond_to?", "extend", "methods"]
     
     @@filters = []
     

--- a/lib/liquid/strainer.rb
+++ b/lib/liquid/strainer.rb
@@ -5,7 +5,7 @@ module Liquid
   #
   # One of the strainer's responsibilities is to keep malicious method calls out 
   class Strainer
-    @@required_methods = ["__send__", "__id__", "object_id", "respond_to?", "extend", "methods"]
+    @@required_methods = [:__send__, :__id__, :object_id, :respond_to?, :extend, :methods]
     
     @@filters = []
     

--- a/lib/support/route_mapper.rb
+++ b/lib/support/route_mapper.rb
@@ -21,7 +21,8 @@ ActionDispatch::Routing::Mapper.class_eval do
     opts[:action] ='show'
     opts[:as] = opts.delete(:named_route)
 		opts[:cache] = "true"
-		opts[:request_method] = "get"
+    opts[:request_method] = "get"
+    opts[:via] = :get
     if opts[:index] == '' # if it maps to the root site URI, name it comatose_root
       #named_route( 'comatose_root', "#{path}/*page", opts )
       opts[:as] = "comatose_root"
@@ -39,13 +40,14 @@ ActionDispatch::Routing::Mapper.class_eval do
       :named_route => 'comatose_admin'
     }.merge(options)
     opts[:as] = opts.delete(:named_route)
-		opts[:request_method] = :get
+    opts[:request_method] = :get
+    opts[:via] = :get
     match("comatose_admin(/:action(/:id))", opts )
 
 
   end
 
-    
+
 #  def method_missing( name, *args, &proc )
 
     #if name.to_s.starts_with?( 'comatose_' )

--- a/lib/support/route_mapper.rb
+++ b/lib/support/route_mapper.rb
@@ -43,26 +43,7 @@ ActionDispatch::Routing::Mapper.class_eval do
     opts[:request_method] = :get
     opts[:via] = :get
     match("comatose_admin(/:action(/:id))", opts )
-
-
   end
-
-
-#  def method_missing( name, *args, &proc )
-
-    #if name.to_s.starts_with?( 'comatose_' )
-#		if args[-1][:controller].starts_with?('comatose')
-#      opts = (args.last.is_a?(Hash)) ? args.pop : {}
-#      opts[:named_route] = name.to_s #[9..-1]
-#      comatose_root( *(args << opt)  )
-#    else
-#      super unless args.length >= 1 && proc.nil?
-#      @set.add_named_route(name, *args)
-#    end
-#  end
-
-
-
 end
 
 


### PR DESCRIPTION
Ruby really doesn't like it:

```
/Users/jakob/Projects/OpenSource/comatose/lib/liquid/strainer.rb:38: warning: undefining `__send__' may cause serious problems
/Users/jakob/Projects/OpenSource/comatose/lib/liquid/strainer.rb:38: warning: undefining `object_id' may cause serious problems
```